### PR TITLE
Add size and lang flags, and fix some UI texts

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,79 +1,22 @@
 package cmd
 
 import (
-	"bufio"
-	"crypto/rand"
-	"fmt"
-	"math/big"
-	"os"
-	"strconv"
-	"unicode"
+	"diceware-cli/diceware"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/text/runes"
-	"golang.org/x/text/transform"
-	"golang.org/x/text/unicode/norm"
 )
 
-var generateCmd = &cobra.Command{
-	Use:   "generate",
-	Short: "Generates a diceware password with 6 words.",
-	Long: `This command generated a diceware password with 6 words
-				using crypto rand to generate random numbers.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		var lang = "en"
-		var words = ""
-		var password = ""
+var (
+	lang string
+	size int32
 
-		for i := 1; i <= 6; i++ {
-			index := findDicewareWordIndex()
-			word := findDicewareWord(index, lang)
-			words = words + word + " "
-			password = password + word
-		}
-
-		fmt.Println("Words: ", words)
-		fmt.Println("Password: ", password)
-	},
-}
-
-func findDicewareWordIndex() string {
-	var number = ""
-	for j := 1; j <= 5; j++ {
-		number = number + strconv.FormatInt(throwDice(), 10)
+	generateCmd = &cobra.Command{
+		Use:   "generate",
+		Short: "Generates a diceware password with custom configuration.",
+		Long: `Generates strong passwords based on easily memorable passwords that are 
+	also extremely resistant to attack.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			diceware.Generate(lang, size)
+		},
 	}
-	return number
-}
-
-func throwDice() int64 {
-	var number int64 = 0
-
-	for number == 0 {
-		nBig, err := rand.Int(rand.Reader, big.NewInt(7))
-		if err != nil {
-			panic(err)
-		}
-		number = nBig.Int64()
-	}
-
-	return number
-}
-
-func findDicewareWord(number string, lang string) string {
-	file, err := os.Open("diceware_words_" + lang + "/" + number + ".txt")
-
-	if err != nil {
-		return ""
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-
-	for scanner.Scan() {
-		word := scanner.Text()
-		t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
-		transformedWord, _, _ := transform.String(t, word)
-		return transformedWord
-	}
-	return ""
-}
+)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,16 +9,18 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "diceware",
-	Short: "Pitcher is a CLI tool to play tones",
-	Long: `A Fast and Flexible Static Site Generator built with
-				  love by spf13 and friends in Go.
-				  Complete documentation is available at http://hugo.spf13.com`,
+	Short: "A generator of diceware passwords.",
+	Long: `diceware-cli let's you generate strong passwords based on easily memorable passwords that are 
+	also extremely resistant to attack.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Pitcher is a CLI tool to play tones. User help to see usage options.")
+		fmt.Println("Use command generate to start generating your strong passwords!")
 	},
 }
 
 func Execute() {
+	generateCmd.Flags().StringVarP(&lang, "lang", "l", "en", "lang (en, pt,...)")
+	generateCmd.Flags().Int32VarP(&size, "size", "s", 6, "how many words the password will have (default to 6 words)")
+
 	rootCmd.AddCommand(generateCmd)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/diceware/diceware.go
+++ b/diceware/diceware.go
@@ -1,0 +1,68 @@
+package diceware
+
+import (
+	"bufio"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"os"
+	"strconv"
+	"unicode"
+
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
+func Generate(lang string, size int32) {
+	var words = ""
+
+	for i := 1; i <= int(size); i++ {
+		index := findDicewareWordIndex()
+		word := findDicewareWord(index, lang)
+		words = words + word + " "
+	}
+
+	fmt.Println(words)
+}
+
+func findDicewareWordIndex() string {
+	var number = ""
+	for j := 1; j <= 5; j++ {
+		number = number + strconv.FormatInt(throwDice(), 10)
+	}
+	return number
+}
+
+func throwDice() int64 {
+	var number int64 = 0
+
+	for number == 0 {
+		nBig, err := rand.Int(rand.Reader, big.NewInt(7))
+		if err != nil {
+			panic(err)
+		}
+		number = nBig.Int64()
+	}
+
+	return number
+}
+
+func findDicewareWord(number string, lang string) string {
+	file, err := os.Open("diceware_words_" + lang + "/" + number + ".txt")
+
+	if err != nil {
+		return ""
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		word := scanner.Text()
+		t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+		transformedWord, _, _ := transform.String(t, word)
+		return transformedWord
+	}
+	return ""
+}


### PR DESCRIPTION
This PR adds support to lang and size selection.

E.g. to select Portuguese as lang: 
`diceware generate --lang=pt`
The default language is English and currently only English and Portuguese is available.

E.g. to generate a password with 7 words: 
`diceware generate --size=7`
The default size is 6.

Closes #3 
Closes #6 