### PR TITLE
Instructs the user to run 'help' command in root cmd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,7 @@ var rootCmd = &cobra.Command{
 	Long: `diceware-cli let's you generate strong passwords based on easily memorable passwords that are 
 	also extremely resistant to attack.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Use command generate to start generating your strong passwords!")
+		fmt.Println("Use command 'generate' to start generating your strong passwords! Or 'help' for more instructions.")
 	},
 }
 


### PR DESCRIPTION
When the user runs `./diceware-cli`, it says to run the `generate` command by default. This PR is a small addition, but I guess it will help new users to discover new options in the future (such as copying to the clipboard!).