### PR TITLE
Capitalize first letters by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Flags:
 
 Example:
 ```
-diceware config --add --lang --source=/Users/diceware-cli/dictionary_file.txt --name=es
+diceware config --add-lang --source=/Users/diceware-cli/dictionary_file.txt --name=es
 ```  
 
 

--- a/README.md
+++ b/README.md
@@ -11,41 +11,36 @@ Usage:
   diceware-cli generate [flags]
 
 Flags:
-  -c, --copy               pbcopy password
+      --copy               pbcopy password
   -h, --help               help for generate
       --hide               pbcopy and hide password. Password WON'T be printed out
-  -l, --lang string        password language
+      --lang string        password language
                             available langs: en, pt (default "en")
+      --lower              remove capitalized first letters
       --separator string   character that separates the words.
                            use --separator=none to remove reparator (default "/")
-  -s, --size int32         the amount words the password will have (default 6)
+      --size int32         the amount words the password will have (default 6)
 ```    
    
 
 ### Add custom language dictionary
 
 ```
-Adds new language dictionary.
-
 Usage:
   diceware-cli config [flags]
 
 Flags:
-  -a, --add             add new config
+      --add             add new config
   -h, --help            help for config
-  -l, --lang            add new language
-  -n, --name string     language name
-  -s, --source string   dictionary source file
+      --lang            add new language
+      --name string     language name
+      --source string   dictionary source file
 ```
 
 Example:
 ```
 diceware config --add --lang --source=/Users/diceware-cli/dictionary_file.txt --name=es
-```
-or
-```
-diceware config -a -l -s=/Users/diceware-cli/dictionary_file.txt -n=es
-```   
+```  
 
 
 ## Installation Guide

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,17 +39,18 @@ var (
 func Execute() {
 	rootCmd.AddCommand(versionCmd)
 
-	generateCmd.Flags().StringVarP(&generateConfig.Lang, "lang", "l", "en", "password language\n available langs: en, pt")
+	generateCmd.Flags().StringVar(&generateConfig.Lang, "lang", "en", "password language\n available langs: en, pt")
 	generateCmd.Flags().StringVar(&generateConfig.Separator, "separator", "/", "character that separates the words.\nuse --separator=none to remove reparator")
-	generateCmd.Flags().Int32VarP(&generateConfig.Size, "size", "s", 6, "the amount words the password will have")
-	generateCmd.Flags().BoolVarP(&generateConfig.Pbcopy, "copy", "c", false, "pbcopy password")
+	generateCmd.Flags().Int32Var(&generateConfig.Size, "size", 6, "the amount words the password will have")
+	generateCmd.Flags().BoolVar(&generateConfig.Pbcopy, "copy", false, "pbcopy password")
 	generateCmd.Flags().BoolVar(&generateConfig.Hide, "hide", false, "pbcopy and hide password. Password WON'T be printed out")
+	generateCmd.Flags().BoolVar(&generateConfig.Lower, "lower", false, "remove capitalized first letters")
 	rootCmd.AddCommand(generateCmd)
 
-	configCmd.Flags().BoolVarP(&customConfig.Add, "add", "a", false, "add new config")
-	configCmd.Flags().BoolVarP(&customConfig.Lang, "lang", "l", false, "add new language")
-	configCmd.Flags().StringVarP(&customConfig.Source, "source", "s", "", "dictionary source file")
-	configCmd.Flags().StringVarP(&customConfig.Name, "name", "n", "", "language name")
+	configCmd.Flags().BoolVar(&customConfig.Add, "add", false, "add new config")
+	configCmd.Flags().BoolVar(&customConfig.Lang, "lang", false, "add new language")
+	configCmd.Flags().StringVar(&customConfig.Source, "source", "", "dictionary source file")
+	configCmd.Flags().StringVar(&customConfig.Name, "name", "", "language name")
 	rootCmd.AddCommand(configCmd)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,8 +47,7 @@ func Execute() {
 	generateCmd.Flags().BoolVar(&generateConfig.Lower, "lower", false, "remove capitalized first letters")
 	rootCmd.AddCommand(generateCmd)
 
-	configCmd.Flags().BoolVar(&customConfig.Add, "add", false, "add new config")
-	configCmd.Flags().BoolVar(&customConfig.Lang, "lang", false, "add new language")
+	configCmd.Flags().BoolVar(&customConfig.AddLang, "add-lang", false, "add new config language")
 	configCmd.Flags().StringVar(&customConfig.Source, "source", "", "dictionary source file")
 	configCmd.Flags().StringVar(&customConfig.Name, "name", "", "language name")
 	rootCmd.AddCommand(configCmd)

--- a/diceware/custom_config.go
+++ b/diceware/custom_config.go
@@ -11,14 +11,13 @@ import (
 )
 
 type CustomConfig struct {
-	Lang   bool
-	Add    bool
-	Source string
-	Name   string
+	AddLang bool
+	Source  string
+	Name    string
 }
 
 func (c *CustomConfig) Configure() error {
-	if c.Add && c.Lang {
+	if c.AddLang {
 		return c.newLanguage()
 	}
 


### PR DESCRIPTION
Also, remove the shorthand letter flags, and add `lower` flag to remove capitalized letters.